### PR TITLE
Fix move assignment

### DIFF
--- a/tagged/unique_ptr.h
+++ b/tagged/unique_ptr.h
@@ -70,6 +70,10 @@ public:
     }
 
     UniquePtr &operator=(UniquePtr &&other) {
+        if (*this == other) {
+            return *this;
+        }
+
         this->cleanup();
 
         // cleanup will zero out our data

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -10,7 +10,12 @@ test_suite(
 cc_test(
     name = "unique_ptr_test",
     srcs = ["unique_ptr_test.cc"],
-    copts = ["-std=c++17"],
+    copts = [
+        "-std=c++17",
+
+        # Warnings disabled for testing bad behavior
+        "-Wno-self-move",
+    ],
     deps = [
         "//tagged",
         "@doctest//doctest",


### PR DESCRIPTION
I missed handling `x = std::move(x);` for `tagged::UniquePtr`.
